### PR TITLE
Issue #8: Add eligibility dual representation schema

### DIFF
--- a/database/migrations/0004_eligibility_dual_representation.sql
+++ b/database/migrations/0004_eligibility_dual_representation.sql
@@ -1,0 +1,79 @@
+-- 0004_eligibility_dual_representation.sql
+-- Eligibility dual representation: raw text + normalized structure + optional logical tree.
+
+begin;
+
+create table if not exists eligibility_clause (
+    eligibility_clause_id bigserial primary key,
+    trial_id bigint not null references trial(trial_id) on delete cascade,
+    document_chunk_id bigint references document_chunk(document_chunk_id) on delete set null,
+    nct_id text not null,
+    criterion_type text not null check (criterion_type in ('inclusion', 'exclusion')),
+    raw_text text not null,
+    normalized_clause jsonb not null default '{}'::jsonb,
+    logical_ast jsonb,
+    source_document_path text,
+    source_snapshot_id text not null,
+    source_system text not null,
+    source_record_id text,
+    source_content_sha256 text not null,
+    char_start integer not null check (char_start >= 0),
+    char_end integer not null check (char_end >= char_start),
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create table if not exists eligibility_tree (
+    eligibility_tree_id bigserial primary key,
+    trial_id bigint not null references trial(trial_id) on delete cascade,
+    root_clause_id bigint references eligibility_clause(eligibility_clause_id) on delete set null,
+    tree_json jsonb not null,
+    tree_version text,
+    source_snapshot_id text not null,
+    source_content_sha256 text,
+    created_at timestamptz not null default now()
+);
+
+create table if not exists criterion_concept_link (
+    criterion_concept_link_id bigserial primary key,
+    eligibility_clause_id bigint not null references eligibility_clause(eligibility_clause_id) on delete cascade,
+    concept_type text not null,
+    concept_id text,
+    concept_label text not null,
+    normalized_value text,
+    char_start integer not null check (char_start >= 0),
+    char_end integer not null check (char_end >= char_start),
+    confidence numeric,
+    source_snapshot_id text not null,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    check (concept_type in ('disease', 'biomarker', 'lab', 'treatment')),
+    check (confidence is null or (confidence >= 0 and confidence <= 1))
+);
+
+create index if not exists idx_eligibility_clause_trial
+    on eligibility_clause (trial_id, criterion_type);
+
+create index if not exists idx_eligibility_clause_nct_id
+    on eligibility_clause (nct_id);
+
+create index if not exists idx_eligibility_clause_snapshot
+    on eligibility_clause (source_snapshot_id);
+
+create index if not exists idx_eligibility_clause_normalized_json
+    on eligibility_clause using gin (normalized_clause);
+
+create index if not exists idx_eligibility_clause_logical_ast
+    on eligibility_clause using gin (logical_ast);
+
+create index if not exists idx_eligibility_clause_offsets
+    on eligibility_clause (source_document_path, char_start, char_end);
+
+create index if not exists idx_criterion_concept_link_clause
+    on criterion_concept_link (eligibility_clause_id);
+
+create index if not exists idx_criterion_concept_link_type_value
+    on criterion_concept_link (concept_type, normalized_value);
+
+commit;

--- a/tests/unit/database/test_eligibility_dual_representation_sql.py
+++ b/tests/unit/database/test_eligibility_dual_representation_sql.py
@@ -1,0 +1,86 @@
+"""Contract tests for eligibility dual representation migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MIGRATION_PATH = Path("database/migrations/0004_eligibility_dual_representation.sql")
+
+
+def _load_sql() -> str:
+    assert MIGRATION_PATH.exists(), f"Expected migration file at {MIGRATION_PATH}"
+    return MIGRATION_PATH.read_text(encoding="utf-8").lower()
+
+
+def test_eligibility_migration_exists():
+    """Eligibility dual-representation migration should exist."""
+    assert MIGRATION_PATH.exists()
+
+
+def test_eligibility_clause_table_contains_dual_representation_fields():
+    """Eligibility clause table should retain raw text plus normalized structure and optional AST."""
+    sql = _load_sql()
+    assert "create table if not exists eligibility_clause" in sql
+
+    table_start = sql.index("create table if not exists eligibility_clause")
+    table_end = sql.index(");", table_start)
+    table_sql = sql[table_start:table_end]
+
+    required_columns = [
+        "trial_id",
+        "nct_id",
+        "raw_text",
+        "normalized_clause jsonb",
+        "logical_ast jsonb",
+        "char_start",
+        "char_end",
+        "source_document_path",
+        "document_chunk_id",
+        "source_snapshot_id",
+        "source_content_sha256",
+    ]
+
+    for column in required_columns:
+        assert column in table_sql
+
+
+def test_eligibility_clause_table_enforces_traceability_constraints():
+    """Eligibility clause rows should preserve offset validity and chunk-level provenance linkage."""
+    sql = _load_sql()
+    table_start = sql.index("create table if not exists eligibility_clause")
+    table_end = sql.index(");", table_start)
+    table_sql = sql[table_start:table_end]
+
+    assert "references trial(trial_id)" in table_sql
+    assert "references document_chunk(document_chunk_id)" in table_sql
+    assert "check (char_start >= 0)" in table_sql
+    assert "check (char_end >= char_start)" in table_sql
+
+
+def test_eligibility_tree_table_exists_for_optional_ast_views():
+    """Migration should include tree table for optional logical-tree representations."""
+    sql = _load_sql()
+
+    assert "create table if not exists eligibility_tree" in sql
+    assert "tree_json jsonb" in sql
+    assert "root_clause_id" in sql
+
+
+def test_concept_link_table_captures_required_concept_types():
+    """Concept link table should support disease/biomarker/lab/treatment mappings."""
+    sql = _load_sql()
+
+    assert "create table if not exists criterion_concept_link" in sql
+    assert "concept_type text not null" in sql
+    assert "check (concept_type in ('disease', 'biomarker', 'lab', 'treatment'))" in sql
+
+
+def test_eligibility_migration_adds_indexes_for_queryability():
+    """Migration should include indexes for JSON lookups, concept links, and text-offset traceability."""
+    sql = _load_sql()
+
+    assert "create index if not exists idx_eligibility_clause_trial" in sql
+    assert "create index if not exists idx_eligibility_clause_normalized_json" in sql
+    assert "using gin (normalized_clause)" in sql
+    assert "create index if not exists idx_eligibility_clause_offsets" in sql
+    assert "create index if not exists idx_criterion_concept_link_type_value" in sql


### PR DESCRIPTION
## Summary
- add `0004_eligibility_dual_representation.sql` for eligibility dual-representation modeling
- retain raw eligibility text and persist normalized clause JSON
- support optional logical tree/AST storage
- add concept-link table for disease, biomarker, lab, and treatment entities
- add offset + source provenance fields for clause-level traceability
- add contract tests covering table structure, constraints, and indexes

## Validation
- uv run --python 3.12 --with pytest --with pytest-asyncio python -m pytest -q -p no:cacheprovider tests/unit/database/test_eligibility_dual_representation_sql.py tests/unit/database/test_data_lineage_controls_sql.py tests/unit/database/test_document_chunk_schema_sql.py tests/unit/database/test_canonical_schema_sql.py tests/unit/processing/test_documents_provenance.py

Closes #8