### PR TITLE
Issue #7: Add Parquet analytics marts + DuckDB export pattern

### DIFF
--- a/clintrai/analytics/__init__.py
+++ b/clintrai/analytics/__init__.py
@@ -1,0 +1,5 @@
+"""Analytics marts exports and query helpers."""
+
+from .marts import FACT_TABLE_SOURCE_MAP, export_analytics_marts
+
+__all__ = ["FACT_TABLE_SOURCE_MAP", "export_analytics_marts"]

--- a/clintrai/analytics/marts.py
+++ b/clintrai/analytics/marts.py
@@ -1,0 +1,205 @@
+"""Parquet analytics marts export using DuckDB."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import statistics
+import time
+
+import duckdb
+
+FACT_TABLE_SOURCE_MAP: dict[str, str] = {
+    "trial_fact": "trial",
+    "arm_fact": "arm",
+    "endpoint_fact": "endpoint",
+    "site_fact": "site",
+    "publication_fact": "publication",
+}
+
+
+@dataclass(frozen=True)
+class MartExportResult:
+    """Summary of a single mart export."""
+
+    source_table: str
+    row_count: int
+    benchmark_runs: int
+    export_seconds: float
+    median_query_seconds: float
+    partition_path: str
+
+
+def _sql_quote(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _source_path(canonical_dir: Path, source_table: str) -> Path:
+    return canonical_dir / f"{source_table}.parquet"
+
+
+def _export_mart(
+    connection: duckdb.DuckDBPyConnection,
+    source_path: Path,
+    fact_output_dir: Path,
+    source_snapshot_id: str,
+) -> tuple[int, float, Path]:
+    fact_output_dir.mkdir(parents=True, exist_ok=True)
+
+    source_path_sql = _sql_quote(str(source_path))
+    fact_output_dir_sql = _sql_quote(str(fact_output_dir))
+    snapshot_sql = _sql_quote(source_snapshot_id)
+
+    start = time.perf_counter()
+    connection.execute(
+        f"""
+        copy (
+            select
+                src.*,
+                '{snapshot_sql}' as source_snapshot_id,
+                now()::timestamptz as exported_at
+            from read_parquet('{source_path_sql}') as src
+        )
+        to '{fact_output_dir_sql}'
+        (format parquet, partition_by (source_snapshot_id), overwrite_or_ignore true);
+        """
+    )
+    export_seconds = time.perf_counter() - start
+
+    partition_path = fact_output_dir / f"source_snapshot_id={source_snapshot_id}"
+
+    row_count = connection.execute(
+        f"""
+        select count(*)
+        from read_parquet('{_sql_quote(str(partition_path / "*.parquet"))}')
+        """
+    ).fetchone()[0]
+
+    return int(row_count), export_seconds, partition_path
+
+
+def _benchmark_query(
+    connection: duckdb.DuckDBPyConnection,
+    partition_path: Path,
+    benchmark_runs: int,
+) -> float:
+    durations: list[float] = []
+    partition_glob_sql = _sql_quote(str(partition_path / "*.parquet"))
+
+    for _ in range(max(1, benchmark_runs)):
+        start = time.perf_counter()
+        connection.execute(
+            f"""
+            select count(*)
+            from read_parquet('{partition_glob_sql}')
+            """
+        ).fetchone()
+        durations.append(time.perf_counter() - start)
+
+    return float(statistics.median(durations))
+
+
+def export_analytics_marts(
+    canonical_dir: Path,
+    output_dir: Path,
+    source_snapshot_id: str,
+    benchmark_runs: int = 3,
+    fact_table_source_map: Mapping[str, str] | None = None,
+) -> dict[str, dict[str, int | float | str]]:
+    """
+    Export canonical tables to partitioned Parquet fact marts with benchmark metadata.
+
+    Args:
+        canonical_dir: Directory containing canonical source parquet files.
+        output_dir: Root output directory for fact marts.
+        source_snapshot_id: Snapshot identifier used as parquet partition key.
+        benchmark_runs: Number of DuckDB query benchmark runs per mart.
+        fact_table_source_map: Optional override of fact->source table mapping.
+
+    Returns:
+        Dictionary keyed by fact table with export and benchmark metadata.
+    """
+    mapping = dict(fact_table_source_map or FACT_TABLE_SOURCE_MAP)
+
+    missing_sources = [
+        source_table
+        for source_table in mapping.values()
+        if not _source_path(canonical_dir, source_table).exists()
+    ]
+    if missing_sources:
+        raise FileNotFoundError(
+            "Missing canonical parquet source files for: " + ", ".join(sorted(missing_sources))
+        )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    results: dict[str, MartExportResult] = {}
+    lineage_map: dict[str, dict[str, str]] = {}
+    benchmark_summary: dict[str, dict[str, int | float | str]] = {}
+
+    connection = duckdb.connect()
+    try:
+        for fact_table, source_table in mapping.items():
+            source_path = _source_path(canonical_dir, source_table)
+            fact_output_dir = output_dir / fact_table
+
+            row_count, export_seconds, partition_path = _export_mart(
+                connection=connection,
+                source_path=source_path,
+                fact_output_dir=fact_output_dir,
+                source_snapshot_id=source_snapshot_id,
+            )
+            median_query_seconds = _benchmark_query(
+                connection=connection,
+                partition_path=partition_path,
+                benchmark_runs=benchmark_runs,
+            )
+
+            result = MartExportResult(
+                source_table=source_table,
+                row_count=row_count,
+                benchmark_runs=benchmark_runs,
+                export_seconds=float(export_seconds),
+                median_query_seconds=median_query_seconds,
+                partition_path=str(partition_path),
+            )
+            results[fact_table] = result
+
+            lineage_map[fact_table] = {
+                "source_table": source_table,
+                "source_parquet": str(source_path),
+                "fact_parquet_dir": str(fact_output_dir),
+                "partition_key": "source_snapshot_id",
+            }
+            benchmark_summary[fact_table] = {
+                "benchmark_runs": benchmark_runs,
+                "export_seconds": result.export_seconds,
+                "median_export_seconds": result.export_seconds,
+                "median_query_seconds": result.median_query_seconds,
+                "row_count": result.row_count,
+            }
+    finally:
+        connection.close()
+
+    (output_dir / "mart_lineage_map.json").write_text(
+        json.dumps(lineage_map, indent=2),
+        encoding="utf-8",
+    )
+    (output_dir / "mart_export_benchmarks.json").write_text(
+        json.dumps(benchmark_summary, indent=2),
+        encoding="utf-8",
+    )
+
+    return {
+        fact_table: {
+            "source_table": result.source_table,
+            "row_count": result.row_count,
+            "benchmark_runs": result.benchmark_runs,
+            "export_seconds": result.export_seconds,
+            "median_query_seconds": result.median_query_seconds,
+            "partition_path": result.partition_path,
+        }
+        for fact_table, result in results.items()
+    }

--- a/docs/analytics/parquet_duckdb_access_pattern.md
+++ b/docs/analytics/parquet_duckdb_access_pattern.md
@@ -1,0 +1,70 @@
+# Parquet Analytics Marts + DuckDB Access Pattern
+
+This document defines the analytics marts for issue #7 and the expected query/benchmark workflow.
+
+## Fact Marts
+The export pipeline defines five fact-table outputs:
+- `trial_fact`
+- `arm_fact`
+- `endpoint_fact`
+- `site_fact`
+- `publication_fact`
+
+Each mart is exported as partitioned Parquet under:
+- `<output_root>/<fact_table>/source_snapshot_id=<snapshot_id>/*.parquet`
+
+## Canonical to Mart Mapping
+| Fact Mart | Canonical Source Table |
+|---|---|
+| `trial_fact` | `trial` |
+| `arm_fact` | `arm` |
+| `endpoint_fact` | `endpoint` |
+| `site_fact` | `site` |
+| `publication_fact` | `publication` |
+
+The export pipeline also writes `mart_lineage_map.json` to preserve table-level lineage mapping.
+
+## Export Pipeline
+Use the CLI wrapper:
+
+```bash
+python scripts/export_analytics_marts.py \
+  --canonical-dir ./canonical_parquet \
+  --output-dir ./analytics_marts \
+  --snapshot-id snapshot-2026-04-03 \
+  --benchmark-runs 5
+```
+
+This writes:
+- partitioned mart parquet datasets,
+- `mart_lineage_map.json`,
+- `mart_export_benchmarks.json`.
+
+## DuckDB Query Examples
+```sql
+-- Total rows in a mart snapshot
+select count(*)
+from read_parquet('analytics_marts/trial_fact/source_snapshot_id=snapshot-2026-04-03/*.parquet');
+
+-- Trial status trend slice
+select overall_status, count(*) as trials
+from read_parquet('analytics_marts/trial_fact/source_snapshot_id=snapshot-2026-04-03/*.parquet')
+group by overall_status
+order by trials desc;
+
+-- Publication counts by journal
+select journal, count(*) as publications
+from read_parquet('analytics_marts/publication_fact/source_snapshot_id=snapshot-2026-04-03/*.parquet')
+group by journal
+order by publications desc
+limit 20;
+```
+
+## Benchmark Notes
+`mart_export_benchmarks.json` includes per-mart metrics:
+- `export_seconds`
+- `median_query_seconds`
+- `row_count`
+- `benchmark_runs`
+
+Use these metrics as baseline benchmarks and compare deltas by snapshot/version.

--- a/scripts/export_analytics_marts.py
+++ b/scripts/export_analytics_marts.py
@@ -1,0 +1,33 @@
+"""CLI for exporting analytics marts to partitioned Parquet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from clintrai.analytics.marts import export_analytics_marts
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export analytics marts from canonical parquet sources")
+    parser.add_argument("--canonical-dir", required=True, type=Path, help="Directory with canonical parquet tables")
+    parser.add_argument("--output-dir", required=True, type=Path, help="Output root for analytics marts")
+    parser.add_argument("--snapshot-id", required=True, help="Snapshot id for parquet partitioning")
+    parser.add_argument("--benchmark-runs", type=int, default=3, help="Number of benchmark query runs per mart")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = export_analytics_marts(
+        canonical_dir=args.canonical_dir,
+        output_dir=args.output_dir,
+        source_snapshot_id=args.snapshot_id,
+        benchmark_runs=args.benchmark_runs,
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/analytics/test_marts_export.py
+++ b/tests/unit/analytics/test_marts_export.py
@@ -1,0 +1,128 @@
+"""Tests for Parquet analytics mart export and DuckDB access pattern."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+
+from clintrai.analytics.marts import export_analytics_marts
+
+
+def _write_canonical_sources(canonical_dir: Path) -> None:
+    canonical_dir.mkdir(parents=True, exist_ok=True)
+
+    pl.DataFrame(
+        {
+            "trial_id": [1, 2],
+            "nct_id": ["NCT0001", "NCT0002"],
+            "overall_status": ["COMPLETED", "RECRUITING"],
+        }
+    ).write_parquet(canonical_dir / "trial.parquet")
+
+    pl.DataFrame(
+        {
+            "arm_id": [10, 11],
+            "trial_id": [1, 2],
+            "arm_label": ["Control", "Treatment"],
+        }
+    ).write_parquet(canonical_dir / "arm.parquet")
+
+    pl.DataFrame(
+        {
+            "endpoint_id": [100, 101],
+            "trial_id": [1, 2],
+            "endpoint_name": ["OS", "PFS"],
+        }
+    ).write_parquet(canonical_dir / "endpoint.parquet")
+
+    pl.DataFrame(
+        {
+            "site_id": [200, 201],
+            "trial_id": [1, 2],
+            "country": ["US", "CA"],
+        }
+    ).write_parquet(canonical_dir / "site.parquet")
+
+    pl.DataFrame(
+        {
+            "publication_id": [300, 301],
+            "trial_id": [1, 2],
+            "journal": ["NEJM", "JAMA"],
+        }
+    ).write_parquet(canonical_dir / "publication.parquet")
+
+
+def test_export_analytics_marts_writes_partitioned_parquet_and_lineage_map(tmp_path):
+    """Export should create required fact marts partitioned by snapshot with lineage map."""
+    canonical_dir = tmp_path / "canonical"
+    output_dir = tmp_path / "analytics_marts"
+    snapshot_id = "snapshot-analytics-001"
+
+    _write_canonical_sources(canonical_dir)
+
+    results = export_analytics_marts(
+        canonical_dir=canonical_dir,
+        output_dir=output_dir,
+        source_snapshot_id=snapshot_id,
+        benchmark_runs=2,
+    )
+
+    required_facts = {
+        "trial_fact": "trial",
+        "arm_fact": "arm",
+        "endpoint_fact": "endpoint",
+        "site_fact": "site",
+        "publication_fact": "publication",
+    }
+
+    assert set(results.keys()) == set(required_facts.keys())
+
+    for fact_table, source_table in required_facts.items():
+        partition_dir = output_dir / fact_table / f"source_snapshot_id={snapshot_id}"
+        parquet_files = list(partition_dir.glob("*.parquet"))
+
+        assert partition_dir.exists()
+        assert parquet_files
+
+        assert results[fact_table]["source_table"] == source_table
+        assert results[fact_table]["row_count"] == 2
+        assert results[fact_table]["benchmark_runs"] == 2
+
+    lineage_map_path = output_dir / "mart_lineage_map.json"
+    assert lineage_map_path.exists()
+
+    lineage_map = json.loads(lineage_map_path.read_text(encoding="utf-8"))
+    assert lineage_map["trial_fact"]["source_table"] == "trial"
+    assert lineage_map["publication_fact"]["source_table"] == "publication"
+
+
+def test_export_analytics_marts_writes_benchmark_summary(tmp_path):
+    """Export should persist benchmark metrics for each mart."""
+    canonical_dir = tmp_path / "canonical"
+    output_dir = tmp_path / "analytics_marts"
+
+    _write_canonical_sources(canonical_dir)
+
+    export_analytics_marts(
+        canonical_dir=canonical_dir,
+        output_dir=output_dir,
+        source_snapshot_id="snapshot-analytics-002",
+        benchmark_runs=3,
+    )
+
+    benchmark_path = output_dir / "mart_export_benchmarks.json"
+    assert benchmark_path.exists()
+
+    benchmark_summary = json.loads(benchmark_path.read_text(encoding="utf-8"))
+    assert set(benchmark_summary.keys()) == {
+        "trial_fact",
+        "arm_fact",
+        "endpoint_fact",
+        "site_fact",
+        "publication_fact",
+    }
+
+    assert benchmark_summary["trial_fact"]["benchmark_runs"] == 3
+    assert benchmark_summary["trial_fact"]["median_export_seconds"] >= 0.0


### PR DESCRIPTION
## Summary
- add analytics mart export module (`clintrai.analytics.marts`) with required fact outputs: trial, arm, endpoint, site, publication
- export partitioned Parquet datasets by `source_snapshot_id`
- persist mart lineage mapping (`mart_lineage_map.json`) linking each mart back to canonical source table
- persist benchmark summary (`mart_export_benchmarks.json`) for query/export timing baselines
- add CLI wrapper `scripts/export_analytics_marts.py`
- add DuckDB query examples and benchmark guidance docs
- add unit tests for partitioned outputs, lineage map, and benchmark artifacts

## Validation
- uv run --python 3.12 --with pytest --with pytest-asyncio python -m pytest -q -p no:cacheprovider tests/unit/analytics/test_marts_export.py tests/unit/database/test_eligibility_dual_representation_sql.py tests/unit/database/test_data_lineage_controls_sql.py tests/unit/database/test_document_chunk_schema_sql.py tests/unit/database/test_canonical_schema_sql.py tests/unit/processing/test_documents_provenance.py

Closes #7