### PR TITLE
Add hybrid retrieval API with metadata + lexical/vector fusion

### DIFF
--- a/clintrai/analytics/__init__.py
+++ b/clintrai/analytics/__init__.py
@@ -1,5 +1,11 @@
 """Analytics marts exports and query helpers."""
 
 from .marts import FACT_TABLE_SOURCE_MAP, export_analytics_marts
+from .retrieval import HybridRetrievalQuery, hybrid_retrieve
 
-__all__ = ["FACT_TABLE_SOURCE_MAP", "export_analytics_marts"]
+__all__ = [
+    "FACT_TABLE_SOURCE_MAP",
+    "HybridRetrievalQuery",
+    "export_analytics_marts",
+    "hybrid_retrieve",
+]

--- a/clintrai/analytics/retrieval.py
+++ b/clintrai/analytics/retrieval.py
@@ -1,0 +1,169 @@
+"""Hybrid retrieval helpers for metadata-constrained lexical + semantic search."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+import math
+import re
+
+_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+_ITERABLE_FILTER_TYPES = (list, tuple, set, frozenset)
+
+
+@dataclass(frozen=True)
+class HybridRetrievalQuery:
+    """Query parameters for hybrid lexical/semantic retrieval."""
+
+    query_text: str
+    query_embedding: Sequence[float] | None = None
+    metadata_filters: Mapping[str, object] = field(default_factory=dict)
+    top_k: int = 20
+    lexical_weight: float = 0.35
+    semantic_weight: float = 0.65
+    min_combined_score: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.top_k <= 0:
+            raise ValueError("top_k must be > 0")
+        if self.lexical_weight < 0 or self.semantic_weight < 0:
+            raise ValueError("lexical_weight and semantic_weight must be >= 0")
+        if self.query_embedding is not None and len(self.query_embedding) == 0:
+            raise ValueError("query_embedding cannot be empty")
+        if self.query_embedding is not None and (self.lexical_weight + self.semantic_weight) <= 0:
+            raise ValueError("semantic retrieval requires lexical_weight + semantic_weight > 0")
+
+
+def _tokenize(text: str) -> list[str]:
+    return _TOKEN_PATTERN.findall(text.lower())
+
+
+def _lexical_score(query_text: str, chunk_text: str) -> float:
+    query_tokens = _tokenize(query_text)
+    if not query_tokens:
+        return 0.0
+
+    chunk_token_set = set(_tokenize(chunk_text))
+    if not chunk_token_set:
+        return 0.0
+
+    matches = sum(1 for token in query_tokens if token in chunk_token_set)
+    return matches / len(query_tokens)
+
+
+def _cosine_similarity(lhs: Sequence[float], rhs: Sequence[float]) -> float:
+    if len(lhs) != len(rhs):
+        return 0.0
+
+    dot = sum(left * right for left, right in zip(lhs, rhs, strict=False))
+    lhs_norm = math.sqrt(sum(value * value for value in lhs))
+    rhs_norm = math.sqrt(sum(value * value for value in rhs))
+    if lhs_norm == 0.0 or rhs_norm == 0.0:
+        return 0.0
+    return dot / (lhs_norm * rhs_norm)
+
+
+def _semantic_score(query_embedding: Sequence[float], candidate_embedding: object) -> float:
+    if not isinstance(candidate_embedding, Sequence):
+        return 0.0
+    if len(candidate_embedding) == 0:
+        return 0.0
+
+    try:
+        candidate_vector = [float(value) for value in candidate_embedding]
+    except (TypeError, ValueError):
+        return 0.0
+
+    return _cosine_similarity([float(value) for value in query_embedding], candidate_vector)
+
+
+def _minmax_normalize(scores: list[float]) -> list[float]:
+    if not scores:
+        return []
+
+    minimum = min(scores)
+    maximum = max(scores)
+    if math.isclose(minimum, maximum):
+        if math.isclose(maximum, 0.0):
+            return [0.0 for _ in scores]
+        return [1.0 for _ in scores]
+
+    denominator = maximum - minimum
+    return [(score - minimum) / denominator for score in scores]
+
+
+def _matches_filters(record: Mapping[str, object], filters: Mapping[str, object]) -> bool:
+    for key, expected in filters.items():
+        actual = record.get(key)
+        if isinstance(expected, _ITERABLE_FILTER_TYPES):
+            if actual not in expected:
+                return False
+            continue
+        if actual != expected:
+            return False
+    return True
+
+
+def hybrid_retrieve(
+    records: Iterable[Mapping[str, object]],
+    query: HybridRetrievalQuery,
+) -> list[dict[str, object]]:
+    """
+    Retrieve top candidates combining metadata filtering, lexical, and vector signals.
+
+    Returns candidate rows with `lexical_score`, `semantic_score`, and `combined_score`
+    while preserving source/provenance identifiers from the input records.
+    """
+    filtered = [record for record in records if _matches_filters(record, query.metadata_filters)]
+    if not filtered:
+        return []
+
+    lexical_scores = [
+        _lexical_score(query.query_text, str(record.get("chunk_text", "")))
+        for record in filtered
+    ]
+    lexical_normalized = _minmax_normalize(lexical_scores)
+
+    semantic_enabled = query.query_embedding is not None
+    semantic_scores = (
+        [
+            _semantic_score(query.query_embedding, record.get("embedding"))
+            for record in filtered
+        ]
+        if semantic_enabled
+        else [0.0 for _ in filtered]
+    )
+    semantic_normalized = _minmax_normalize(semantic_scores)
+
+    if semantic_enabled:
+        weight_total = query.lexical_weight + query.semantic_weight
+        lexical_weight = query.lexical_weight / weight_total
+        semantic_weight = query.semantic_weight / weight_total
+    else:
+        lexical_weight = 1.0
+        semantic_weight = 0.0
+
+    scored_rows: list[dict[str, object]] = []
+    for index, record in enumerate(filtered):
+        combined_score = (
+            lexical_normalized[index] * lexical_weight
+            + semantic_normalized[index] * semantic_weight
+        )
+        if combined_score < query.min_combined_score:
+            continue
+
+        row = dict(record)
+        row["lexical_score"] = lexical_normalized[index]
+        row["semantic_score"] = semantic_normalized[index]
+        row["combined_score"] = combined_score
+        scored_rows.append(row)
+
+    scored_rows.sort(
+        key=lambda row: (
+            -float(row["combined_score"]),
+            -float(row["semantic_score"]),
+            -float(row["lexical_score"]),
+            str(row.get("document_chunk_id", "")),
+        )
+    )
+    return scored_rows[: query.top_k]

--- a/tests/unit/analytics/test_hybrid_retrieval.py
+++ b/tests/unit/analytics/test_hybrid_retrieval.py
@@ -1,0 +1,142 @@
+"""Tests for hybrid retrieval (metadata filters + lexical + vector)."""
+
+from __future__ import annotations
+
+import time
+
+from clintrai.analytics.retrieval import HybridRetrievalQuery, hybrid_retrieve
+
+
+def _sample_records() -> list[dict[str, object]]:
+    return [
+        {
+            "document_chunk_id": 1,
+            "nct_id": "NCT1001",
+            "chunk_text": "Eligibility includes EGFR mutation positive NSCLC patients.",
+            "source_snapshot_id": "snapshot-a",
+            "source_content_sha256": "hash-a",
+            "source_document_path": "docs/protocol_a.pdf",
+            "country": "US",
+            "study_phase": "PHASE2",
+            "embedding": [0.10, 0.20, 0.30],
+        },
+        {
+            "document_chunk_id": 2,
+            "nct_id": "NCT1002",
+            "chunk_text": "Exclusion criteria include uncontrolled hypertension and renal failure.",
+            "source_snapshot_id": "snapshot-b",
+            "source_content_sha256": "hash-b",
+            "source_document_path": "docs/protocol_b.pdf",
+            "country": "US",
+            "study_phase": "PHASE2",
+            "embedding": [0.90, 0.10, 0.10],
+        },
+        {
+            "document_chunk_id": 3,
+            "nct_id": "NCT2001",
+            "chunk_text": "Inclusion requires prior PD-1 exposure and measurable disease.",
+            "source_snapshot_id": "snapshot-c",
+            "source_content_sha256": "hash-c",
+            "source_document_path": "docs/protocol_c.pdf",
+            "country": "CA",
+            "study_phase": "PHASE3",
+            "embedding": [0.95, 0.05, 0.05],
+        },
+    ]
+
+
+def test_hybrid_retrieve_supports_metadata_filters_and_vector_similarity():
+    """Metadata filters should constrain rows before semantic ranking."""
+    query = HybridRetrievalQuery(
+        query_text="EGFR mutation positive",
+        query_embedding=[0.10, 0.20, 0.30],
+        metadata_filters={"country": "US", "study_phase": "PHASE2"},
+        top_k=2,
+    )
+
+    results = hybrid_retrieve(_sample_records(), query)
+
+    assert len(results) == 2
+    assert {r["document_chunk_id"] for r in results} == {1, 2}
+    assert results[0]["document_chunk_id"] == 1
+
+
+def test_hybrid_retrieve_uses_lexical_fallback_when_query_embedding_missing():
+    """Lexical ranking should still return good candidates when embedding is absent."""
+    query = HybridRetrievalQuery(
+        query_text="uncontrolled hypertension",
+        query_embedding=None,
+        metadata_filters={"country": "US"},
+        top_k=2,
+    )
+
+    results = hybrid_retrieve(_sample_records(), query)
+
+    assert results
+    assert results[0]["document_chunk_id"] == 2
+    assert results[0]["lexical_score"] > 0.0
+    assert results[0]["combined_score"] > 0.0
+
+
+def test_hybrid_retrieve_returns_source_provenance_fields():
+    """Returned hits should include source/provenance identifiers."""
+    query = HybridRetrievalQuery(
+        query_text="pd-1 measurable disease",
+        query_embedding=[0.95, 0.05, 0.05],
+        metadata_filters={"country": "CA"},
+        top_k=1,
+    )
+
+    result = hybrid_retrieve(_sample_records(), query)[0]
+
+    assert result["nct_id"] == "NCT2001"
+    assert result["source_snapshot_id"] == "snapshot-c"
+    assert result["source_content_sha256"] == "hash-c"
+    assert result["source_document_path"] == "docs/protocol_c.pdf"
+
+
+def test_hybrid_retrieve_smoke_precision_and_latency():
+    """Smoke test: relevant top hit and bounded runtime for moderate candidate set."""
+    records = []
+    for idx in range(500):
+        records.append(
+            {
+                "document_chunk_id": idx + 100,
+                "nct_id": f"NCT{idx:04d}",
+                "chunk_text": f"background sentence {idx}",
+                "source_snapshot_id": "snapshot-z",
+                "source_content_sha256": f"hash-{idx}",
+                "source_document_path": f"docs/{idx}.pdf",
+                "country": "US",
+                "study_phase": "PHASE2",
+                "embedding": [0.0, 1.0, 0.0],
+            }
+        )
+
+    records.append(
+        {
+            "document_chunk_id": 42,
+            "nct_id": "NCTBEST",
+            "chunk_text": "Eligibility requires EGFR exon 19 deletion and measurable disease.",
+            "source_snapshot_id": "snapshot-best",
+            "source_content_sha256": "hash-best",
+            "source_document_path": "docs/best.pdf",
+            "country": "US",
+            "study_phase": "PHASE2",
+            "embedding": [1.0, 0.0, 0.0],
+        }
+    )
+
+    query = HybridRetrievalQuery(
+        query_text="egfr exon 19 deletion measurable disease",
+        query_embedding=[1.0, 0.0, 0.0],
+        metadata_filters={"country": "US", "study_phase": "PHASE2"},
+        top_k=5,
+    )
+
+    start = time.perf_counter()
+    results = hybrid_retrieve(records, query)
+    elapsed = time.perf_counter() - start
+
+    assert results[0]["document_chunk_id"] == 42
+    assert elapsed < 1.0


### PR DESCRIPTION
## Summary
- add `HybridRetrievalQuery` and `hybrid_retrieve` for metadata-constrained hybrid retrieval
- combine lexical token overlap with cosine similarity scoring and normalized rank fusion
- return provenance-rich hit payloads with deterministic top-k ranking
- add unit tests for metadata filters, lexical fallback, provenance fields, and latency smoke

## Testing
- `uv run --with pytest python -m pytest -q tests/unit/analytics/test_hybrid_retrieval.py`
- `uv run --with pytest python -m pytest -q tests/unit/analytics/test_marts_export.py tests/unit/analytics/test_hybrid_retrieval.py`
- `uv run --with ruff ruff check clintrai/analytics/retrieval.py tests/unit/analytics/test_hybrid_retrieval.py`

Closes #6
