### PR TITLE
Add PostGIS site geography schema, indexes, and query surfaces

### DIFF
--- a/database/migrations/0005_postgis_site_geography.sql
+++ b/database/migrations/0005_postgis_site_geography.sql
@@ -1,0 +1,150 @@
+-- 0005_postgis_site_geography.sql
+-- PostGIS support for site selection and recruitment geography analysis.
+
+begin;
+
+create extension if not exists postgis;
+
+alter table site
+    add column if not exists site_point geometry(point, 4326)
+    generated always as (
+        case
+            when latitude is not null and longitude is not null
+                then st_setsrid(st_makepoint(longitude, latitude), 4326)
+            else null
+        end
+    ) stored;
+
+alter table site
+    add column if not exists site_geog geography(point, 4326)
+    generated always as (
+        case
+            when latitude is not null and longitude is not null
+                then st_setsrid(st_makepoint(longitude, latitude), 4326)::geography
+            else null
+        end
+    ) stored;
+
+create index if not exists idx_site_site_point_gist
+    on site using gist (site_point);
+
+create index if not exists idx_site_site_geog_gist
+    on site using gist (site_geog);
+
+create index if not exists idx_site_country_state
+    on site (country, state);
+
+create index if not exists idx_site_trial_country
+    on site (trial_id, country);
+
+create or replace view site_trial_geography as
+select
+    s.site_id,
+    s.trial_id,
+    t.nct_id,
+    t.overall_status,
+    s.facility_name,
+    s.city,
+    s.state,
+    s.country,
+    s.postal_code,
+    s.latitude,
+    s.longitude,
+    s.site_point,
+    s.site_geog,
+    s.source_snapshot_id,
+    s.source_system,
+    s.source_record_id,
+    s.source_content_sha256
+from site s
+join trial t on t.trial_id = s.trial_id;
+
+create or replace function sites_within_radius_km(
+    center_lat double precision,
+    center_lon double precision,
+    radius_km double precision default 50.0,
+    max_results integer default 500
+)
+returns table (
+    site_id bigint,
+    trial_id bigint,
+    nct_id text,
+    facility_name text,
+    city text,
+    state text,
+    country text,
+    distance_km double precision
+)
+language sql
+stable
+as $$
+    select
+        s.site_id,
+        s.trial_id,
+        t.nct_id,
+        s.facility_name,
+        s.city,
+        s.state,
+        s.country,
+        st_distance(
+            s.site_geog,
+            st_setsrid(st_makepoint(center_lon, center_lat), 4326)::geography
+        ) / 1000.0 as distance_km
+    from site s
+    join trial t on t.trial_id = s.trial_id
+    where s.site_geog is not null
+      and st_dwithin(
+          s.site_geog,
+          st_setsrid(st_makepoint(center_lon, center_lat), 4326)::geography,
+          radius_km * 1000.0
+      )
+    order by distance_km asc
+    limit greatest(max_results, 1);
+$$;
+
+create or replace function site_catchment_summary(
+    radius_km double precision default 50.0
+)
+returns table (
+    site_id bigint,
+    trial_id bigint,
+    nct_id text,
+    nearby_site_count bigint,
+    nearby_trial_count bigint
+)
+language sql
+stable
+as $$
+    select
+        anchor.site_id,
+        anchor.trial_id,
+        t.nct_id,
+        count(neighbor.site_id) filter (
+            where neighbor.site_id is not null and neighbor.site_id <> anchor.site_id
+        ) as nearby_site_count,
+        count(distinct neighbor.trial_id) filter (
+            where neighbor.site_id is not null and neighbor.site_id <> anchor.site_id
+        ) as nearby_trial_count
+    from site anchor
+    join trial t on t.trial_id = anchor.trial_id
+    left join site neighbor
+        on anchor.site_geog is not null
+       and neighbor.site_geog is not null
+       and st_dwithin(anchor.site_geog, neighbor.site_geog, radius_km * 1000.0)
+    group by anchor.site_id, anchor.trial_id, t.nct_id;
+$$;
+
+create or replace view region_site_coverage as
+select
+    coalesce(s.country, 'unknown') as country,
+    coalesce(s.state, 'unknown') as state,
+    count(*) as site_count,
+    count(distinct s.trial_id) as trial_count,
+    count(distinct t.sponsor_id) as sponsor_count,
+    st_centroid(st_collect(s.site_point))::geometry(point, 4326) as coverage_centroid
+from site s
+join trial t on t.trial_id = s.trial_id
+where s.site_point is not null
+group by 1, 2;
+
+commit;

--- a/docs/analytics/postgis_site_geography_access_pattern.md
+++ b/docs/analytics/postgis_site_geography_access_pattern.md
@@ -1,0 +1,53 @@
+# PostGIS Site Geography Access Pattern
+
+This document defines the geospatial model and baseline query surfaces added for issue #3.
+
+## Schema Additions
+Migration `0005_postgis_site_geography.sql` extends canonical `site` with:
+- `site_point geometry(point, 4326)` for planar geometry operations and map projection compatibility.
+- `site_geog geography(point, 4326)` for meter-accurate distance/radius filtering.
+
+Both columns are generated from canonical `longitude` + `latitude` using:
+- `st_setsrid(st_makepoint(longitude, latitude), 4326)`
+
+## Indexing Strategy
+Implemented indexes:
+- `idx_site_site_point_gist` on `site_point` for geometry predicates.
+- `idx_site_site_geog_gist` on `site_geog` for radius/distance filters (`st_dwithin`).
+- `idx_site_country_state` on `(country, state)` for region coverage grouping/filtering.
+- `idx_site_trial_country` on `(trial_id, country)` for trial-scoped geography slices.
+
+This mix supports both spatial filtering and relational drill-down paths.
+
+## Canonical Integration Surface
+`site_trial_geography` view joins canonical trial + site records and keeps:
+- trial keys: `trial_id`, `nct_id`, `overall_status`
+- site location fields and PostGIS points
+- lineage fields: `source_snapshot_id`, `source_system`, `source_record_id`, `source_content_sha256`
+
+## Baseline Query Surfaces
+Migration-provided SQL interfaces:
+- `sites_within_radius_km(center_lat, center_lon, radius_km, max_results)`
+- `site_catchment_summary(radius_km)`
+- `region_site_coverage` view
+
+### Radius Search
+```sql
+select *
+from sites_within_radius_km(39.7392, -104.9903, 75.0, 200);
+```
+
+### Catchment Summary
+```sql
+select *
+from site_catchment_summary(100.0)
+order by nearby_trial_count desc, nearby_site_count desc
+limit 50;
+```
+
+### Regional Coverage
+```sql
+select country, state, site_count, trial_count, sponsor_count
+from region_site_coverage
+order by site_count desc, trial_count desc;
+```

--- a/tests/unit/database/test_postgis_site_geography_sql.py
+++ b/tests/unit/database/test_postgis_site_geography_sql.py
@@ -1,0 +1,60 @@
+"""Contract tests for PostGIS site geography migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MIGRATION_PATH = Path("database/migrations/0005_postgis_site_geography.sql")
+
+
+def _load_sql() -> str:
+    assert MIGRATION_PATH.exists(), f"Expected migration file at {MIGRATION_PATH}"
+    return MIGRATION_PATH.read_text(encoding="utf-8").lower()
+
+
+def test_postgis_site_geography_migration_exists():
+    """PostGIS site geography migration should exist."""
+    assert MIGRATION_PATH.exists()
+
+
+def test_site_table_adds_geometry_and_geography_columns_with_srid():
+    """Site schema should include geometry/geography point columns with SRID 4326."""
+    sql = _load_sql()
+
+    assert "create extension if not exists postgis" in sql
+    assert "add column if not exists site_point geometry(point, 4326)" in sql
+    assert "add column if not exists site_geog geography(point, 4326)" in sql
+    assert "st_setsrid(st_makepoint(longitude, latitude), 4326)" in sql
+
+
+def test_postgis_indexing_strategy_is_implemented():
+    """Migration should include spatial and regional indexes for distance/coverage workloads."""
+    sql = _load_sql()
+
+    assert "create index if not exists idx_site_site_point_gist" in sql
+    assert "on site using gist (site_point)" in sql
+    assert "create index if not exists idx_site_site_geog_gist" in sql
+    assert "on site using gist (site_geog)" in sql
+    assert "create index if not exists idx_site_country_state" in sql
+    assert "create index if not exists idx_site_trial_country" in sql
+
+
+def test_baseline_geospatial_query_surfaces_exist():
+    """Radius, catchment, and region coverage query surfaces should be present."""
+    sql = _load_sql()
+
+    assert "create or replace function sites_within_radius_km" in sql
+    assert "st_dwithin" in sql
+    assert "create or replace function site_catchment_summary" in sql
+    assert "count(distinct neighbor.trial_id)" in sql
+    assert "create or replace view region_site_coverage" in sql
+
+
+def test_geospatial_outputs_are_joined_to_canonical_trial_site_entities():
+    """Geospatial outputs should be linked to canonical trial and site entities."""
+    sql = _load_sql()
+
+    assert "create or replace view site_trial_geography" in sql
+    assert "from site s" in sql
+    assert "join trial t on t.trial_id = s.trial_id" in sql
+    assert "t.nct_id" in sql


### PR DESCRIPTION
## Summary
- add PostGIS migration `0005_postgis_site_geography.sql` for canonical `site` geospatial support
- add `site_point` geometry and `site_geog` geography generated columns with SRID 4326
- implement spatial/regional indexing strategy for distance and coverage workloads
- add baseline geospatial query surfaces for radius, catchment, and region coverage
- add access-pattern documentation and SQL contract tests

## Testing
- `uv run --with pytest python -m pytest -q tests/unit/database/test_postgis_site_geography_sql.py`
- `uv run --with pytest python -m pytest -q tests/unit/database`
- `uv run --with ruff ruff check tests/unit/database/test_postgis_site_geography_sql.py`

Closes #3
