### PR TITLE
Define Neo4j projection schema, sync strategy, and query catalog

### DIFF
--- a/docs/analytics/neo4j_projection_query_catalog.cypher
+++ b/docs/analytics/neo4j_projection_query_catalog.cypher
@@ -1,0 +1,35 @@
+// Neo4j projection query catalog for issue #5.
+// Graph is a non-authoritative projection from canonical Postgres.
+
+// Use Case 1: Competitive landscape by mechanism
+// Example: PD-1 trials in GI cancers with biomarker-linked evidence.
+MATCH (t:Trial)-[:HAS_INTERVENTION]->(i:Intervention)
+MATCH (t)-[:STUDIES]->(c:Condition)
+OPTIONAL MATCH (t)-[:HAS_BIOMARKER]->(b:Biomarker)
+WHERE toLower(i.intervention_name) CONTAINS "pd-1"
+  AND toLower(c.condition_name) CONTAINS "gastro"
+RETURN t.trial_id, t.nct_id, i.intervention_name, c.condition_name,
+       collect(distinct b.biomarker_name) AS biomarkers
+ORDER BY t.nct_id
+LIMIT 100;
+
+// Use Case 2: Sponsor portfolio exploration across disease areas
+MATCH (s:Sponsor)-[:SPONSORS]->(t:Trial)-[:STUDIES]->(c:Condition)
+RETURN s.sponsor_name, c.condition_name, count(distinct t) AS trial_count
+ORDER BY trial_count DESC
+LIMIT 50;
+
+// Use Case 3: Endpoint strategy discovery by condition
+MATCH (t:Trial)-[:MEASURES]->(e:Endpoint)
+MATCH (t)-[:STUDIES]->(c:Condition)
+RETURN c.condition_name, e.endpoint_type, e.endpoint_name, count(distinct t) AS trials
+ORDER BY trials DESC
+LIMIT 100;
+
+// Use Case 4: Evidence graph drill-down
+MATCH (t:Trial {nct_id: $nct_id})-[:HAS_PUBLICATION]->(p:Publication)
+RETURN t.nct_id, p.publication_id, p.title, p.journal, p.published_at,
+       p.source_snapshot_id
+ORDER BY p.published_at DESC
+LIMIT 25;
+

--- a/docs/plans/2026-04-12-neo4j-projection-design.md
+++ b/docs/plans/2026-04-12-neo4j-projection-design.md
@@ -1,0 +1,131 @@
+# Neo4j Projection Design for Relationship-Centric Exploration
+
+Date: 2026-04-12  
+Issue: #5  
+Branch: `issue/5-neo4j-projection-relationship-centric-exploration`
+
+## Goal
+Define a derived Neo4j projection for multi-hop exploration workloads while keeping Postgres as the single authoritative source of truth.
+
+## Authority Boundary (Required)
+- Canonical authority remains in Postgres.
+- Neo4j is a read-optimized projection only.
+- No writes originate from Neo4j back into canonical entities.
+- If projection and canonical data disagree, Postgres wins and projection is rebuilt/replayed.
+
+## Graph Schema as a Projection from Canonical Postgres
+
+### Node Labels and Source Mapping
+| Node Label | Canonical Source |
+|---|---|
+| `Trial` | `trial` |
+| `Sponsor` | `sponsor` |
+| `Arm` | `arm` |
+| `Intervention` | `intervention` |
+| `Condition` | `condition` |
+| `Biomarker` | `biomarker` |
+| `Endpoint` | `endpoint` |
+| `Publication` | `publication` |
+| `Site` | `site` |
+
+### Relationship Types and Source Mapping
+| Relationship | Canonical Derivation |
+|---|---|
+| `(:Sponsor)-[:SPONSORS]->(:Trial)` | `trial.sponsor_id -> sponsor.sponsor_id` |
+| `(:Trial)-[:HAS_ARM]->(:Arm)` | `arm.trial_id -> trial.trial_id` |
+| `(:Trial)-[:HAS_INTERVENTION]->(:Intervention)` | `intervention.trial_id -> trial.trial_id` |
+| `(:Trial)-[:STUDIES]->(:Condition)` | `condition.trial_id -> trial.trial_id` |
+| `(:Trial)-[:MEASURES]->(:Endpoint)` | `endpoint.trial_id -> trial.trial_id` |
+| `(:Trial)-[:HAS_BIOMARKER]->(:Biomarker)` | `biomarker.trial_id -> trial.trial_id` |
+| `(:Trial)-[:HAS_PUBLICATION]->(:Publication)` | `publication.trial_id -> trial.trial_id` |
+| `(:Trial)-[:HAS_SITE]->(:Site)` | `site.trial_id -> trial.trial_id` |
+
+### Required Node Identity Keys
+- `Trial.trial_id` and `Trial.nct_id`
+- `{Entity}.<table>_id` for each projected entity
+- `source_snapshot_id` on every projected node and relationship for lineage
+
+### Required Constraints and Indexes (Neo4j)
+```cypher
+CREATE CONSTRAINT trial_id_unique IF NOT EXISTS
+FOR (t:Trial) REQUIRE t.trial_id IS UNIQUE;
+
+CREATE CONSTRAINT sponsor_id_unique IF NOT EXISTS
+FOR (s:Sponsor) REQUIRE s.sponsor_id IS UNIQUE;
+
+CREATE CONSTRAINT arm_id_unique IF NOT EXISTS
+FOR (a:Arm) REQUIRE a.arm_id IS UNIQUE;
+
+CREATE CONSTRAINT intervention_id_unique IF NOT EXISTS
+FOR (i:Intervention) REQUIRE i.intervention_id IS UNIQUE;
+
+CREATE CONSTRAINT condition_id_unique IF NOT EXISTS
+FOR (c:Condition) REQUIRE c.condition_id IS UNIQUE;
+
+CREATE CONSTRAINT biomarker_id_unique IF NOT EXISTS
+FOR (b:Biomarker) REQUIRE b.biomarker_id IS UNIQUE;
+
+CREATE CONSTRAINT endpoint_id_unique IF NOT EXISTS
+FOR (e:Endpoint) REQUIRE e.endpoint_id IS UNIQUE;
+
+CREATE CONSTRAINT publication_id_unique IF NOT EXISTS
+FOR (p:Publication) REQUIRE p.publication_id IS UNIQUE;
+
+CREATE CONSTRAINT site_id_unique IF NOT EXISTS
+FOR (s:Site) REQUIRE s.site_id IS UNIQUE;
+
+CREATE INDEX trial_nct_id IF NOT EXISTS
+FOR (t:Trial) ON (t.nct_id);
+```
+
+## ETL Sync Strategy (Incremental + Replay)
+
+### Bootstrap (Initial Full Load)
+1. Export canonical entities from Postgres in deterministic entity order.
+2. Load nodes via `MERGE` on immutable IDs.
+3. Load relationships via `MERGE` on node IDs and relationship type.
+4. Stamp `source_snapshot_id` and `projected_at`.
+
+### Incremental Sync
+- Watermark input: `updated_at` + `source_snapshot_id` from canonical tables.
+- Pull changed rows since last successful watermark.
+- Upsert nodes and relationships with `MERGE`.
+- Soft deletes represented with `is_active=false` on nodes/relationships when canonical row is no longer valid.
+- Persist sync checkpoints in a Postgres table (`graph_projection_checkpoint`) to keep auditability near canonical lineage.
+
+### Replay / Backfill
+- Triggered by explicit snapshot range or lineage replay request.
+- Delete+rebuild scope:
+  - per `source_snapshot_id`, or
+  - per entity family (for targeted repair).
+- Replay is idempotent because `MERGE` keys are canonical IDs and relationship identities.
+
+### Consistency Guardrails
+- Projection job must fail closed if source extract contains referential breaks.
+- Daily reconciliation checks:
+  - node count parity by entity label vs canonical tables,
+  - edge count parity by relationship type,
+  - sample key consistency checks (`trial_id`, `nct_id`, `source_snapshot_id`).
+
+## Core Traversal Queries Validated Against Product Use Cases
+Query catalog: `docs/analytics/neo4j_projection_query_catalog.cypher`
+
+### Use Case 1: Competitive landscape by mechanism
+- Need: trials connected to specific biomarker + intervention pattern.
+- Validation: query returns `Trial`, linked `Biomarker`, and `Intervention` nodes with source IDs.
+
+### Use Case 2: Sponsor portfolio exploration across disease areas
+- Need: sponsor-to-trial-to-condition multi-hop traversal with aggregation.
+- Validation: query groups trials by sponsor and condition, returns top portfolios.
+
+### Use Case 3: Endpoint strategy discovery
+- Need: identify trials measuring endpoint families across conditions.
+- Validation: query traverses `Trial -> Endpoint` and `Trial -> Condition` and returns explainable paths.
+
+### Use Case 4: Evidence graph drill-down
+- Need: from trial to publications and supporting context.
+- Validation: query returns `Trial -> Publication` paths with provenance properties.
+
+## Operational Note
+- This projection is intentionally non-authoritative and can be rebuilt from canonical Postgres + lineage snapshots.
+- Consumer services must treat Neo4j as a query accelerator, not as a transactional source of truth.

--- a/tests/unit/docs/test_neo4j_projection_design_doc.py
+++ b/tests/unit/docs/test_neo4j_projection_design_doc.py
@@ -1,0 +1,66 @@
+"""Contract tests for Neo4j projection design documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DESIGN_DOC_PATH = Path("docs/plans/2026-04-12-neo4j-projection-design.md")
+QUERY_CATALOG_PATH = Path("docs/analytics/neo4j_projection_query_catalog.cypher")
+
+
+def _load_design_doc() -> str:
+    assert DESIGN_DOC_PATH.exists(), f"Expected design doc at {DESIGN_DOC_PATH}"
+    return DESIGN_DOC_PATH.read_text(encoding="utf-8").lower()
+
+
+def _load_query_catalog() -> str:
+    assert QUERY_CATALOG_PATH.exists(), f"Expected query catalog at {QUERY_CATALOG_PATH}"
+    return QUERY_CATALOG_PATH.read_text(encoding="utf-8").lower()
+
+
+def test_design_doc_and_query_catalog_exist():
+    """Neo4j projection design artifacts should exist."""
+    assert DESIGN_DOC_PATH.exists()
+    assert QUERY_CATALOG_PATH.exists()
+
+
+def test_design_doc_defines_projection_schema_from_canonical():
+    """Design doc should define graph schema as a canonical projection."""
+    content = _load_design_doc()
+
+    assert "graph schema as a projection from canonical postgres" in content
+    assert "node labels and source mapping" in content
+    assert "relationship types and source mapping" in content
+    assert "trial" in content
+    assert "sponsor" in content
+
+
+def test_design_doc_documents_incremental_and_replay_sync_strategy():
+    """ETL strategy should include bootstrap, incremental sync, and replay/backfill."""
+    content = _load_design_doc()
+
+    assert "etl sync strategy (incremental + replay)" in content
+    assert "bootstrap (initial full load)" in content
+    assert "incremental sync" in content
+    assert "replay / backfill" in content
+    assert "merge" in content
+
+
+def test_query_catalog_covers_core_traversal_use_cases():
+    """Core traversal query use cases should be represented in the query catalog."""
+    content = _load_query_catalog()
+
+    assert "use case 1" in content
+    assert "use case 2" in content
+    assert "use case 3" in content
+    assert "use case 4" in content
+    assert "match (s:sponsor)-[:sponsors]->(t:trial)-[:studies]->(c:condition)" in content
+
+
+def test_design_doc_marks_graph_layer_non_authoritative():
+    """Design doc must explicitly mark Neo4j as non-authoritative."""
+    content = _load_design_doc()
+
+    assert "non-authoritative" in content
+    assert "postgres wins" in content
+    assert "query accelerator" in content


### PR DESCRIPTION
## Summary
- add Neo4j projection design doc defining graph schema as a projection from canonical Postgres
- document incremental sync and replay/backfill ETL strategy with reconciliation guardrails
- add core traversal query catalog mapped to product use cases
- explicitly enforce non-authoritative graph boundary (Postgres remains source of truth)
- add docs contract tests to keep acceptance requirements enforced in CI

## Testing
- `uv run --with pytest python -m pytest -q tests/unit/docs/test_neo4j_projection_design_doc.py`
- `uv run --with pytest python -m pytest -q tests/unit/docs tests/unit/database/test_postgis_site_geography_sql.py`
- `uv run --with ruff ruff check tests/unit/docs/test_neo4j_projection_design_doc.py`

Closes #5
