### PR TITLE
Reuse one HTTP client per document download run

### DIFF
--- a/clintrai/processing/documents.py
+++ b/clintrai/processing/documents.py
@@ -260,9 +260,9 @@ async def download_documents(
     # Use semaphore to limit concurrent downloads
     semaphore = asyncio.Semaphore(max_concurrent)
 
-    async def download_with_limit(doc_info: DocumentInfo) -> DocumentInfo:
-        async with semaphore:
-            async with client_factory() as client:
+    async with client_factory() as client:
+        async def download_with_limit(doc_info: DocumentInfo) -> DocumentInfo:
+            async with semaphore:
                 return await _download_single_document(
                     client,
                     doc_info,
@@ -271,13 +271,13 @@ async def download_documents(
                     max_size_mb,
                 )
 
-    logger.info(f"Starting download of {len(documents)} documents with {max_concurrent} concurrent connections")
+        logger.info(f"Starting download of {len(documents)} documents with {max_concurrent} concurrent connections")
 
-    # Download all documents
-    updated_documents = await asyncio.gather(
-        *[download_with_limit(doc) for doc in documents],
-        return_exceptions=True
-    )
+        # Download all documents through one connection pool.
+        updated_documents = await asyncio.gather(
+            *[download_with_limit(doc) for doc in documents],
+            return_exceptions=True,
+        )
 
     # Handle any exceptions from gather
     results = []

--- a/tests/unit/processing/test_documents_client_lifecycle.py
+++ b/tests/unit/processing/test_documents_client_lifecycle.py
@@ -1,0 +1,53 @@
+"""Tests for document downloader HTTP client lifecycle behavior."""
+
+from __future__ import annotations
+
+import httpx
+import polars as pl
+import pytest
+
+from clintrai.models.types import HarmonizedFieldName
+from clintrai.processing import documents as documents_module
+
+
+@pytest.mark.asyncio
+async def test_download_documents_uses_single_shared_client_per_run(tmp_path):
+    """Downloader should create one client per run and reuse it across documents."""
+    harmonized_df = pl.DataFrame(
+        {
+            HarmonizedFieldName.NCT_ID.value: ["NCT00010001"],
+            HarmonizedFieldName.DOCUMENT_URLS.value: [
+                [
+                    "Protocol, https://example.com/protocol_v1.pdf",
+                    "SAP, https://example.com/sap_v1.pdf",
+                ],
+            ],
+        }
+    )
+    documents = documents_module.extract_document_info(harmonized_df, snapshot_id="snapshot-client")
+
+    factory_calls = 0
+
+    def _client_factory() -> httpx.AsyncClient:
+        nonlocal factory_calls
+        factory_calls += 1
+        transport = httpx.MockTransport(
+            lambda _request: httpx.Response(200, content=b"%PDF-1.7 sample content")
+        )
+        return httpx.AsyncClient(transport=transport)
+
+    records, stats = await documents_module.download_documents(
+        documents=documents,
+        output_dir=tmp_path / "documents",
+        client_factory=_client_factory,
+        max_concurrent=2,
+        max_size_mb=5,
+        raw_artifacts_dir=tmp_path / "raw_artifacts",
+    )
+
+    assert factory_calls == 1
+    assert len(records) == 2
+    assert stats["downloaded"] == 2
+    assert stats["failed"] == 0
+    assert stats["skipped"] == 0
+    assert all(record["status"] == "downloaded" for record in records)


### PR DESCRIPTION
## Summary
- create one shared HTTP client context per document-download run
- preserve semaphore-based per-document concurrency limits
- add a multi-document lifecycle test proving the client factory is invoked once
- preserve download, provenance, and statistics behavior

## Validation
- 76 unit tests passed
- focused Ruff correctness checks passed

Closes #21