### PR TITLE
Add deterministic CI quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: Run unit tests
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: >-
+          uv run --no-project
+          --with pytest
+          --with pytest-asyncio
+          --with pydantic
+          --with polars
+          --with httpx
+          --with loguru
+          --with duckdb
+          python -m pytest -q -p no:cacheprovider
+
+      - name: Run Ruff correctness checks
+        run: >-
+          uv run --no-project --with ruff
+          ruff check clintrai tests scripts airflow
+          --select E9,F63,F7,F82,B
+
+      - name: Build package artifacts
+        run: uv build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
           --with pydantic
           --with polars
           --with httpx
+          --with curl-cffi
+          --with tenacity
           --with loguru
           --with duckdb
           python -m pytest -q -p no:cacheprovider

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The default test command runs deterministic unit tests and excludes live API int
 ```bash
 PYTHONDONTWRITEBYTECODE=1 uv run --no-project \
   --with pytest --with pytest-asyncio \
-  --with pydantic --with polars --with httpx --with loguru --with duckdb \
+  --with pydantic --with polars --with httpx --with curl-cffi --with tenacity \
+  --with loguru --with duckdb \
   python -m pytest -q -p no:cacheprovider
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# clintrAI
+
+Clinical-trial ingestion, normalization, document processing, and retrieval experiments.
+
+## Quality Gates
+
+The default test command runs deterministic unit tests and excludes live API integration tests:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 uv run --no-project \
+  --with pytest --with pytest-asyncio \
+  --with pydantic --with polars --with httpx --with loguru --with duckdb \
+  python -m pytest -q -p no:cacheprovider
+```
+
+Run the correctness-focused Ruff baseline:
+
+```bash
+uv run --no-project --with ruff \
+  ruff check clintrai tests scripts airflow --select E9,F63,F7,F82,B
+```
+
+Build the package:
+
+```bash
+uv build
+```
+
+Live ClinicalTrials.gov tests are opt-in:
+
+```bash
+uv run --no-project \
+  --with pytest --with pytest-asyncio \
+  --with pydantic --with httpx --with curl-cffi --with tenacity \
+  python -m pytest -m integration tests/integration
+```
+
+GitHub Actions runs the same unit, static-analysis, and build gates on pull requests and pushes to `main`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ addopts = [
     "-v",
     "--strict-markers",
     "--tb=short",
+    "-m",
+    "not integration",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/tests/integration/api/test_stats.py
+++ b/tests/integration/api/test_stats.py
@@ -4,6 +4,8 @@ import pytest
 from clintrai.api.hybrid_client import create_hybrid_client
 from clintrai.api import stats
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.asyncio
 async def test_get_size_stats_live():

--- a/tests/integration/api/test_studies.py
+++ b/tests/integration/api/test_studies.py
@@ -6,6 +6,8 @@ from clintrai.api import studies
 from clintrai.models.api_models import PagedStudies, Study
 from clintrai.api.exceptions import NotFoundError
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.asyncio
 async def test_list_studies_live():

--- a/tests/unit/api/test_protocols.py
+++ b/tests/unit/api/test_protocols.py
@@ -33,8 +33,8 @@ def test_protocol_compliance():
     # Test that the client has the required methods
     assert hasattr(client, "get")
     assert hasattr(client, "close")
-    assert callable(getattr(client, "get"))
-    assert callable(getattr(client, "close"))
+    assert callable(client.get)
+    assert callable(client.close)
 
 
 def test_protocol_methods_exist():


### PR DESCRIPTION
## Summary
- add GitHub Actions gates for Python 3.12 unit tests, Ruff correctness checks, and package builds
- mark all live ClinicalTrials.gov tests as integration tests
- exclude integration tests from default test execution
- document local unit, lint, build, and opt-in integration commands
- correct two protocol assertions required by the Ruff correctness baseline

## Validation
- 76 unit tests passed; 13 integration tests deselected by default
- 13 integration tests are selected by the documented opt-in command
- Ruff correctness gate passed
- workflow YAML parsed successfully
- package source distribution and wheel built successfully

Closes #22