### PR TITLE
Make source snapshots immutable and detect changed documents

### DIFF
--- a/clintrai/processing/documents.py
+++ b/clintrai/processing/documents.py
@@ -23,6 +23,7 @@ from clintrai.models.types import HarmonizedFieldName
 DocumentInfo: TypeAlias = dict[str, Any]
 DownloadStats: TypeAlias = dict[str, Any]
 HttpClient: TypeAlias = httpx.AsyncClient
+_SNAPSHOT_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 
 
 def _utc_now_iso() -> str:
@@ -34,6 +35,16 @@ def _generate_snapshot_id() -> str:
     """Generate a unique source snapshot identifier."""
     timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     return f"snapshot-{timestamp}-{uuid4().hex[:8]}"
+
+
+def _create_snapshot_dir(output_dir: Path, snapshot_id: str) -> Path:
+    """Reserve an immutable directory for one source snapshot."""
+    if _SNAPSHOT_ID_PATTERN.fullmatch(snapshot_id) is None:
+        raise ValueError(f"Invalid snapshot identifier: {snapshot_id!r}")
+
+    snapshot_dir = output_dir / "snapshots" / snapshot_id
+    snapshot_dir.mkdir(parents=True, exist_ok=False)
+    return snapshot_dir
 
 
 def _persist_raw_artifact(
@@ -135,14 +146,21 @@ def _extract_filename(url: str) -> str:
     return filename if filename else "unknown_document.pdf"
 
 
-def _create_safe_path(output_dir: Path, nct_id: str, filename: str) -> Path:
+def _create_safe_path(
+    output_dir: Path,
+    nct_id: str,
+    source_url: str,
+    filename: str,
+) -> Path:
     """Create safe local file path for document."""
-    study_dir = output_dir / nct_id
-    study_dir.mkdir(parents=True, exist_ok=True)
+    safe_nct_id = re.sub(r"[^\w\-.]", "_", nct_id)
+    source_id = hashlib.sha256(source_url.encode()).hexdigest()[:16]
+    source_dir = output_dir / safe_nct_id / source_id
+    source_dir.mkdir(parents=True, exist_ok=True)
 
     # Sanitize filename
     safe_filename = re.sub(r"[^\w\-_\.]", "_", filename)
-    return study_dir / safe_filename
+    return source_dir / safe_filename
 
 
 async def _download_single_document(
@@ -165,30 +183,22 @@ async def _download_single_document(
         Updated document info with download status
     """
     try:
-        local_path = _create_safe_path(output_dir, doc_info["nct_id"], doc_info["filename"])
-        fetched_at = _utc_now_iso()
-
-        # Skip if already exists
+        local_path = _create_safe_path(
+            output_dir,
+            doc_info["nct_id"],
+            doc_info["url"],
+            doc_info["filename"],
+        )
+        existing_hash = None
         if local_path.exists():
-            existing_content = local_path.read_bytes()
-            artifact_path, content_hash = _persist_raw_artifact(
-                raw_artifacts_dir,
-                existing_content,
-                doc_info["filename"],
-            )
-            doc_info["local_path"] = str(local_path)
-            doc_info["file_size"] = local_path.stat().st_size
-            doc_info["status"] = "skipped"
-            doc_info["source_content_sha256"] = content_hash
-            doc_info["raw_artifact_path"] = str(artifact_path)
-            doc_info["source_fetched_at"] = None
-            return doc_info
+            existing_hash = hashlib.sha256(local_path.read_bytes()).hexdigest()
 
         # Download with timeout and size limits
         response = await client.get(doc_info["url"], timeout=60.0)
         response.raise_for_status()
 
         content = response.content
+        fetched_at = _utc_now_iso()
 
         # Check file size
         if len(content) > max_size_mb * 1024 * 1024:
@@ -202,13 +212,15 @@ async def _download_single_document(
             doc_info["filename"],
         )
 
-        # Save file
-        local_path.write_bytes(content)
+        if existing_hash != content_hash:
+            local_path.write_bytes(content)
 
         # Update document info
         doc_info["local_path"] = str(local_path)
         doc_info["file_size"] = len(content)
-        doc_info["status"] = "downloaded"
+        doc_info["status"] = (
+            "skipped" if existing_hash == content_hash else "downloaded"
+        )
         doc_info["source_content_sha256"] = content_hash
         doc_info["raw_artifact_path"] = str(artifact_path)
         doc_info["source_fetched_at"] = fetched_at
@@ -414,6 +426,7 @@ async def process_document_downloads(
     logger.info("Starting document download process")
     output_dir.mkdir(parents=True, exist_ok=True)
     run_snapshot_id = snapshot_id or _generate_snapshot_id()
+    snapshot_dir = _create_snapshot_dir(output_dir, run_snapshot_id)
 
     # Extract document information
     documents = extract_document_info(harmonized_df, run_snapshot_id)
@@ -422,10 +435,12 @@ async def process_document_downloads(
         logger.warning("No documents found to download")
         save_source_snapshot_metadata(
             [],
-            output_dir / "source_snapshot.parquet",
+            snapshot_dir / "source_snapshot.parquet",
             run_snapshot_id,
         )
-        return [], _create_empty_stats()
+        stats = _create_empty_stats()
+        stats["snapshot_id"] = run_snapshot_id
+        return [], stats
 
     # Download documents with dependency injection
     updated_documents, stats = await download_documents(
@@ -439,11 +454,11 @@ async def process_document_downloads(
     stats["snapshot_id"] = run_snapshot_id
 
     # Save metadata
-    metadata_path = output_dir / "document_metadata.parquet"
+    metadata_path = snapshot_dir / "document_metadata.parquet"
     save_document_metadata(updated_documents, metadata_path)
     save_source_snapshot_metadata(
         updated_documents,
-        output_dir / "source_snapshot.parquet",
+        snapshot_dir / "source_snapshot.parquet",
         run_snapshot_id,
     )
 

--- a/clintrai/processing/documents.py
+++ b/clintrai/processing/documents.py
@@ -9,6 +9,7 @@ import hashlib
 import os
 from pathlib import Path
 import re
+import tempfile
 from typing import Any, TypeAlias
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -64,17 +65,35 @@ def _persist_raw_artifact(
     artifact_path = raw_artifacts_dir / content_hash[:2] / f"{content_hash}{file_extension}"
     artifact_path.parent.mkdir(parents=True, exist_ok=True)
 
-    try:
-        fd = os.open(
-            artifact_path,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-            0o644,
-        )
-    except FileExistsError:
+    def validate_existing_artifact() -> None:
+        existing_hash = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+        if existing_hash != content_hash:
+            raise RuntimeError(
+                f"Raw artifact integrity check failed: {artifact_path}"
+            )
+
+    if artifact_path.exists():
+        validate_existing_artifact()
         return artifact_path, content_hash
 
-    with os.fdopen(fd, "wb") as handle:
-        handle.write(content)
+    fd, temporary_name = tempfile.mkstemp(
+        dir=artifact_path.parent,
+        prefix=f".{content_hash}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        try:
+            os.link(temporary_path, artifact_path)
+        except FileExistsError:
+            validate_existing_artifact()
+    finally:
+        temporary_path.unlink(missing_ok=True)
 
     return artifact_path, content_hash
 
@@ -183,22 +202,22 @@ async def _download_single_document(
         Updated document info with download status
     """
     try:
-        local_path = _create_safe_path(
-            output_dir,
-            doc_info["nct_id"],
-            doc_info["url"],
-            doc_info["filename"],
-        )
-        existing_hash = None
-        if local_path.exists():
-            existing_hash = hashlib.sha256(local_path.read_bytes()).hexdigest()
-
         # Download with timeout and size limits
         response = await client.get(doc_info["url"], timeout=60.0)
         response.raise_for_status()
 
         content = response.content
         fetched_at = _utc_now_iso()
+        artifact_path, content_hash = _persist_raw_artifact(
+            raw_artifacts_dir,
+            content,
+            doc_info["filename"],
+        )
+
+        doc_info["file_size"] = len(content)
+        doc_info["source_content_sha256"] = content_hash
+        doc_info["raw_artifact_path"] = str(artifact_path)
+        doc_info["source_fetched_at"] = fetched_at
 
         # Check file size
         if len(content) > max_size_mb * 1024 * 1024:
@@ -206,24 +225,17 @@ async def _download_single_document(
             doc_info["error"] = f"File too large: {len(content) / 1024 / 1024:.1f}MB"
             return doc_info
 
-        artifact_path, content_hash = _persist_raw_artifact(
-            raw_artifacts_dir,
-            content,
+        local_path = _create_safe_path(
+            output_dir,
+            doc_info["nct_id"],
+            doc_info["url"],
             doc_info["filename"],
         )
-
-        if existing_hash != content_hash:
-            local_path.write_bytes(content)
+        local_path.write_bytes(content)
 
         # Update document info
         doc_info["local_path"] = str(local_path)
-        doc_info["file_size"] = len(content)
-        doc_info["status"] = (
-            "skipped" if existing_hash == content_hash else "downloaded"
-        )
-        doc_info["source_content_sha256"] = content_hash
-        doc_info["raw_artifact_path"] = str(artifact_path)
-        doc_info["source_fetched_at"] = fetched_at
+        doc_info["status"] = "downloaded"
 
         logger.debug(f"Downloaded {doc_info['nct_id']}/{doc_info['filename']} ({len(content) / 1024:.1f}KB)")
 
@@ -365,6 +377,9 @@ def save_source_snapshot_metadata(
     documents: list[DocumentInfo],
     output_path: Path,
     snapshot_id: str,
+    *,
+    status: str = "completed",
+    error: str | None = None,
 ) -> None:
     """Save source snapshot summary metadata to parquet."""
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -378,6 +393,8 @@ def save_source_snapshot_metadata(
     snapshot_row = {
         "snapshot_id": snapshot_id,
         "created_at": _utc_now_iso(),
+        "status": status,
+        "error": error,
         "document_count": len(documents),
         "downloaded_count": downloaded_count,
         "skipped_count": skipped_count,
@@ -425,50 +442,63 @@ async def process_document_downloads(
     """
     logger.info("Starting document download process")
     output_dir.mkdir(parents=True, exist_ok=True)
-    run_snapshot_id = snapshot_id or _generate_snapshot_id()
+    run_snapshot_id = snapshot_id if snapshot_id is not None else _generate_snapshot_id()
     snapshot_dir = _create_snapshot_dir(output_dir, run_snapshot_id)
+    documents: list[DocumentInfo] = []
 
-    # Extract document information
-    documents = extract_document_info(harmonized_df, run_snapshot_id)
+    try:
+        # Extract document information
+        documents = extract_document_info(harmonized_df, run_snapshot_id)
 
-    if not documents:
-        logger.warning("No documents found to download")
+        if not documents:
+            logger.warning("No documents found to download")
+            save_source_snapshot_metadata(
+                [],
+                snapshot_dir / "source_snapshot.parquet",
+                run_snapshot_id,
+            )
+            stats = _create_empty_stats()
+            stats["snapshot_id"] = run_snapshot_id
+            return [], stats
+
+        # Download documents with dependency injection
+        updated_documents, stats = await download_documents(
+            documents,
+            snapshot_dir / "documents",
+            create_httpx_client,  # Injected client factory
+            max_concurrent,
+            max_size_mb,
+            raw_artifacts_dir=output_dir / "raw_artifacts",
+        )
+        stats["snapshot_id"] = run_snapshot_id
+
+        # Save metadata
+        metadata_path = snapshot_dir / "document_metadata.parquet"
+        save_document_metadata(updated_documents, metadata_path)
         save_source_snapshot_metadata(
-            [],
+            updated_documents,
             snapshot_dir / "source_snapshot.parquet",
             run_snapshot_id,
         )
-        stats = _create_empty_stats()
-        stats["snapshot_id"] = run_snapshot_id
-        return [], stats
 
-    # Download documents with dependency injection
-    updated_documents, stats = await download_documents(
-        documents,
-        output_dir / "documents",
-        create_httpx_client,  # Injected client factory
-        max_concurrent,
-        max_size_mb,
-        raw_artifacts_dir=output_dir / "raw_artifacts",
-    )
-    stats["snapshot_id"] = run_snapshot_id
+        # Log summary
+        logger.info("Document download summary:")
+        logger.info(f"  Studies with documents: {stats['studies_with_documents']:,}")
+        logger.info(f"  Total documents: {stats['total_documents']:,}")
+        logger.info(f"  Downloaded: {stats['downloaded']:,}")
+        logger.info(f"  Failed: {stats['failed']:,}")
+        logger.info(f"  Skipped: {stats['skipped']:,}")
+        logger.info(f"  Total size: {stats['total_size_mb']:.1f} MB")
 
-    # Save metadata
-    metadata_path = snapshot_dir / "document_metadata.parquet"
-    save_document_metadata(updated_documents, metadata_path)
-    save_source_snapshot_metadata(
-        updated_documents,
-        snapshot_dir / "source_snapshot.parquet",
-        run_snapshot_id,
-    )
-
-    # Log summary
-    logger.info("Document download summary:")
-    logger.info(f"  Studies with documents: {stats['studies_with_documents']:,}")
-    logger.info(f"  Total documents: {stats['total_documents']:,}")
-    logger.info(f"  Downloaded: {stats['downloaded']:,}")
-    logger.info(f"  Failed: {stats['failed']:,}")
-    logger.info(f"  Skipped: {stats['skipped']:,}")
-    logger.info(f"  Total size: {stats['total_size_mb']:.1f} MB")
-
-    return updated_documents, stats
+        return updated_documents, stats
+    except Exception as exc:
+        failure_manifest_path = snapshot_dir / "source_snapshot.parquet"
+        if not failure_manifest_path.exists():
+            save_source_snapshot_metadata(
+                documents,
+                failure_manifest_path,
+                run_snapshot_id,
+                status="failed",
+                error=str(exc),
+            )
+        raise

--- a/tests/unit/processing/test_documents_provenance.py
+++ b/tests/unit/processing/test_documents_provenance.py
@@ -54,13 +54,17 @@ async def test_process_document_downloads_writes_snapshot_and_provenance(tmp_pat
     assert Path(record["raw_artifact_path"]).exists()
     assert record["source_fetched_at"] is not None
 
-    metadata_df = pl.read_parquet(tmp_path / "document_metadata.parquet")
+    snapshot_dir = tmp_path / "snapshots" / "snapshot-001"
+    metadata_df = pl.read_parquet(snapshot_dir / "document_metadata.parquet")
     assert "source_snapshot_id" in metadata_df.columns
     assert "source_content_sha256" in metadata_df.columns
+    assert "url" in metadata_df.columns
+    assert "source_fetched_at" in metadata_df.columns
+    assert "raw_artifact_path" in metadata_df.columns
     assert metadata_df[0, "source_snapshot_id"] == "snapshot-001"
     assert metadata_df[0, "source_content_sha256"] == expected_hash
 
-    snapshot_df = pl.read_parquet(tmp_path / "source_snapshot.parquet")
+    snapshot_df = pl.read_parquet(snapshot_dir / "source_snapshot.parquet")
     assert snapshot_df[0, "snapshot_id"] == "snapshot-001"
     assert snapshot_df[0, "document_count"] == 1
     assert snapshot_df[0, "downloaded_count"] == 1
@@ -109,7 +113,7 @@ async def test_process_document_downloads_no_docs_writes_snapshot(tmp_path):
     assert records == []
     assert stats["total_documents"] == 0
 
-    snapshot_path = output_dir / "source_snapshot.parquet"
+    snapshot_path = output_dir / "snapshots" / "snapshot-empty" / "source_snapshot.parquet"
     assert snapshot_path.exists()
 
     snapshot_df = pl.read_parquet(snapshot_path)
@@ -119,8 +123,8 @@ async def test_process_document_downloads_no_docs_writes_snapshot(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_skipped_documents_keep_hash_without_new_fetch_timestamp(tmp_path, monkeypatch):
-    """Skipped documents should keep content hash provenance without recording a fresh fetch timestamp."""
+async def test_unchanged_documents_are_refetched_and_reuse_artifact(tmp_path, monkeypatch):
+    """Unchanged documents should be revalidated and reuse their content-addressed artifact."""
     content = b"%PDF-1.7 stable content"
     output_dir = tmp_path / "output"
     harmonized_df = pl.DataFrame(
@@ -132,8 +136,15 @@ async def test_skipped_documents_keep_hash_without_new_fetch_timestamp(tmp_path,
         }
     )
 
+    request_count = 0
+
     def _mock_client_factory() -> httpx.AsyncClient:
-        transport = httpx.MockTransport(lambda request: httpx.Response(200, content=content))
+        def _handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            request_count += 1
+            return httpx.Response(200, content=content)
+
+        transport = httpx.MockTransport(_handler)
         return httpx.AsyncClient(transport=transport)
 
     monkeypatch.setattr(documents_module, "create_httpx_client", _mock_client_factory)
@@ -154,9 +165,118 @@ async def test_skipped_documents_keep_hash_without_new_fetch_timestamp(tmp_path,
     expected_hash = hashlib.sha256(content).hexdigest()
     skipped_record = second_records[0]
 
+    assert request_count == 2
     assert skipped_record["status"] == "skipped"
     assert skipped_record["source_snapshot_id"] == "snapshot-second"
     assert skipped_record["source_content_sha256"] == expected_hash
-    assert skipped_record["source_fetched_at"] is None
+    assert skipped_record["source_fetched_at"] is not None
     assert skipped_record["raw_artifact_path"] is not None
     assert Path(skipped_record["raw_artifact_path"]).exists()
+    assert skipped_record["raw_artifact_path"] == first_records[0]["raw_artifact_path"]
+
+    assert (output_dir / "snapshots" / "snapshot-first" / "document_metadata.parquet").exists()
+    assert (output_dir / "snapshots" / "snapshot-second" / "document_metadata.parquet").exists()
+
+
+@pytest.mark.asyncio
+async def test_changed_document_at_same_url_creates_new_artifact(tmp_path, monkeypatch):
+    """Changed bytes at a stable URL should create a new immutable artifact."""
+    contents = iter([b"%PDF-1.7 version one", b"%PDF-1.7 version two"])
+    output_dir = tmp_path / "output"
+    harmonized_df = pl.DataFrame(
+        {
+            HarmonizedFieldName.NCT_ID.value: ["NCT00000004"],
+            HarmonizedFieldName.DOCUMENT_URLS.value: [
+                ["Protocol, https://example.com/protocol.pdf"],
+            ],
+        }
+    )
+
+    def _mock_client_factory() -> httpx.AsyncClient:
+        transport = httpx.MockTransport(
+            lambda _request: httpx.Response(200, content=next(contents))
+        )
+        return httpx.AsyncClient(transport=transport)
+
+    monkeypatch.setattr(documents_module, "create_httpx_client", _mock_client_factory)
+
+    first_records, _ = await documents_module.process_document_downloads(
+        harmonized_df=harmonized_df,
+        output_dir=output_dir,
+        snapshot_id="snapshot-change-1",
+    )
+    second_records, _ = await documents_module.process_document_downloads(
+        harmonized_df=harmonized_df,
+        output_dir=output_dir,
+        snapshot_id="snapshot-change-2",
+    )
+
+    first_record = first_records[0]
+    second_record = second_records[0]
+
+    assert first_record["status"] == "downloaded"
+    assert second_record["status"] == "downloaded"
+    assert first_record["source_content_sha256"] != second_record["source_content_sha256"]
+    assert first_record["raw_artifact_path"] != second_record["raw_artifact_path"]
+    assert Path(first_record["raw_artifact_path"]).exists()
+    assert Path(second_record["raw_artifact_path"]).exists()
+    assert Path(second_record["local_path"]).read_bytes() == b"%PDF-1.7 version two"
+
+
+@pytest.mark.asyncio
+async def test_same_filename_from_different_urls_has_distinct_local_identity(tmp_path, monkeypatch):
+    """Different source URLs must not collide when their filenames match."""
+    harmonized_df = pl.DataFrame(
+        {
+            HarmonizedFieldName.NCT_ID.value: ["NCT00000005"],
+            HarmonizedFieldName.DOCUMENT_URLS.value: [
+                [
+                    "Protocol, https://primary.example.com/files/protocol.pdf",
+                    "Protocol, https://mirror.example.com/files/protocol.pdf",
+                ],
+            ],
+        }
+    )
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=str(request.url).encode())
+
+    def _mock_client_factory() -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+
+    monkeypatch.setattr(documents_module, "create_httpx_client", _mock_client_factory)
+
+    records, stats = await documents_module.process_document_downloads(
+        harmonized_df=harmonized_df,
+        output_dir=tmp_path,
+        snapshot_id="snapshot-collision",
+    )
+
+    local_paths = {record["local_path"] for record in records}
+    assert stats["downloaded"] == 2
+    assert len(local_paths) == 2
+    assert all(Path(path).exists() for path in local_paths)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_identifier_cannot_be_reused(tmp_path):
+    """Snapshot directories should be append-only and reject duplicate identifiers."""
+    harmonized_df = pl.DataFrame(
+        {
+            HarmonizedFieldName.NCT_ID.value: ["NCT00000006"],
+            HarmonizedFieldName.DOCUMENT_URLS.value: [[]],
+        }
+    )
+
+    await documents_module.process_document_downloads(
+        harmonized_df=harmonized_df,
+        output_dir=tmp_path,
+        snapshot_id="snapshot-immutable",
+    )
+
+    with pytest.raises(FileExistsError):
+        await documents_module.process_document_downloads(
+            harmonized_df=harmonized_df,
+            output_dir=tmp_path,
+            snapshot_id="snapshot-immutable",
+        )

--- a/tests/unit/processing/test_documents_provenance.py
+++ b/tests/unit/processing/test_documents_provenance.py
@@ -66,6 +66,7 @@ async def test_process_document_downloads_writes_snapshot_and_provenance(tmp_pat
 
     snapshot_df = pl.read_parquet(snapshot_dir / "source_snapshot.parquet")
     assert snapshot_df[0, "snapshot_id"] == "snapshot-001"
+    assert snapshot_df[0, "status"] == "completed"
     assert snapshot_df[0, "document_count"] == 1
     assert snapshot_df[0, "downloaded_count"] == 1
 
@@ -93,6 +94,23 @@ def test_persist_raw_artifact_is_content_addressed_and_idempotent(tmp_path):
     assert len(artifact_files) == 1
 
 
+def test_persist_raw_artifact_rejects_corrupt_existing_content(tmp_path):
+    """An existing artifact must match the hash encoded in its path."""
+    raw_artifacts_dir = tmp_path / "raw_artifacts"
+    content = b"expected-content"
+    content_hash = hashlib.sha256(content).hexdigest()
+    artifact_path = raw_artifacts_dir / content_hash[:2] / f"{content_hash}.pdf"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_bytes(b"corrupt")
+
+    with pytest.raises(RuntimeError, match="integrity check failed"):
+        documents_module._persist_raw_artifact(
+            raw_artifacts_dir,
+            content,
+            "protocol.pdf",
+        )
+
+
 @pytest.mark.asyncio
 async def test_process_document_downloads_no_docs_writes_snapshot(tmp_path):
     """No-document runs should still persist source snapshot metadata."""
@@ -118,6 +136,7 @@ async def test_process_document_downloads_no_docs_writes_snapshot(tmp_path):
 
     snapshot_df = pl.read_parquet(snapshot_path)
     assert snapshot_df[0, "snapshot_id"] == "snapshot-empty"
+    assert snapshot_df[0, "status"] == "completed"
     assert snapshot_df[0, "document_count"] == 0
     assert snapshot_df[0, "downloaded_count"] == 0
 
@@ -163,16 +182,17 @@ async def test_unchanged_documents_are_refetched_and_reuse_artifact(tmp_path, mo
     )
 
     expected_hash = hashlib.sha256(content).hexdigest()
-    skipped_record = second_records[0]
+    unchanged_record = second_records[0]
 
     assert request_count == 2
-    assert skipped_record["status"] == "skipped"
-    assert skipped_record["source_snapshot_id"] == "snapshot-second"
-    assert skipped_record["source_content_sha256"] == expected_hash
-    assert skipped_record["source_fetched_at"] is not None
-    assert skipped_record["raw_artifact_path"] is not None
-    assert Path(skipped_record["raw_artifact_path"]).exists()
-    assert skipped_record["raw_artifact_path"] == first_records[0]["raw_artifact_path"]
+    assert unchanged_record["status"] == "downloaded"
+    assert unchanged_record["source_snapshot_id"] == "snapshot-second"
+    assert unchanged_record["source_content_sha256"] == expected_hash
+    assert unchanged_record["source_fetched_at"] is not None
+    assert unchanged_record["raw_artifact_path"] is not None
+    assert Path(unchanged_record["raw_artifact_path"]).exists()
+    assert unchanged_record["raw_artifact_path"] == first_records[0]["raw_artifact_path"]
+    assert unchanged_record["local_path"] != first_records[0]["local_path"]
 
     assert (output_dir / "snapshots" / "snapshot-first" / "document_metadata.parquet").exists()
     assert (output_dir / "snapshots" / "snapshot-second" / "document_metadata.parquet").exists()
@@ -220,6 +240,8 @@ async def test_changed_document_at_same_url_creates_new_artifact(tmp_path, monke
     assert first_record["raw_artifact_path"] != second_record["raw_artifact_path"]
     assert Path(first_record["raw_artifact_path"]).exists()
     assert Path(second_record["raw_artifact_path"]).exists()
+    assert first_record["local_path"] != second_record["local_path"]
+    assert Path(first_record["local_path"]).read_bytes() == b"%PDF-1.7 version one"
     assert Path(second_record["local_path"]).read_bytes() == b"%PDF-1.7 version two"
 
 
@@ -279,4 +301,91 @@ async def test_snapshot_identifier_cannot_be_reused(tmp_path):
             harmonized_df=harmonized_df,
             output_dir=tmp_path,
             snapshot_id="snapshot-immutable",
+        )
+
+
+@pytest.mark.asyncio
+async def test_failed_run_persists_failure_manifest(tmp_path, monkeypatch):
+    """A reserved snapshot should record an unexpected processing failure."""
+    harmonized_df = pl.DataFrame(
+        {
+            HarmonizedFieldName.NCT_ID.value: ["NCT00000007"],
+            HarmonizedFieldName.DOCUMENT_URLS.value: [[]],
+        }
+    )
+
+    def _raise_extraction_error(*_args, **_kwargs):
+        raise RuntimeError("extraction failed")
+
+    monkeypatch.setattr(
+        documents_module,
+        "extract_document_info",
+        _raise_extraction_error,
+    )
+
+    with pytest.raises(RuntimeError, match="extraction failed"):
+        await documents_module.process_document_downloads(
+            harmonized_df=harmonized_df,
+            output_dir=tmp_path,
+            snapshot_id="snapshot-failed",
+        )
+
+    snapshot_df = pl.read_parquet(
+        tmp_path / "snapshots" / "snapshot-failed" / "source_snapshot.parquet"
+    )
+    assert snapshot_df[0, "status"] == "failed"
+    assert snapshot_df[0, "error"] == "extraction failed"
+
+
+@pytest.mark.asyncio
+async def test_oversized_response_preserves_fetch_provenance(tmp_path, monkeypatch):
+    """Fetched bytes should remain auditable even when materialization is rejected."""
+    content = b"oversized"
+    harmonized_df = pl.DataFrame(
+        {
+            HarmonizedFieldName.NCT_ID.value: ["NCT00000008"],
+            HarmonizedFieldName.DOCUMENT_URLS.value: [
+                ["Protocol, https://example.com/oversized.pdf"],
+            ],
+        }
+    )
+
+    def _mock_client_factory() -> httpx.AsyncClient:
+        transport = httpx.MockTransport(
+            lambda _request: httpx.Response(200, content=content)
+        )
+        return httpx.AsyncClient(transport=transport)
+
+    monkeypatch.setattr(documents_module, "create_httpx_client", _mock_client_factory)
+
+    records, stats = await documents_module.process_document_downloads(
+        harmonized_df=harmonized_df,
+        output_dir=tmp_path,
+        max_size_mb=0,
+        snapshot_id="snapshot-oversized",
+    )
+
+    record = records[0]
+    assert stats["failed"] == 1
+    assert record["status"] == "failed"
+    assert record["source_fetched_at"] is not None
+    assert record["source_content_sha256"] == hashlib.sha256(content).hexdigest()
+    assert Path(record["raw_artifact_path"]).read_bytes() == content
+
+
+@pytest.mark.asyncio
+async def test_empty_snapshot_identifier_is_rejected(tmp_path):
+    """An explicitly empty snapshot identifier should not be silently replaced."""
+    harmonized_df = pl.DataFrame(
+        {
+            HarmonizedFieldName.NCT_ID.value: ["NCT00000009"],
+            HarmonizedFieldName.DOCUMENT_URLS.value: [[]],
+        }
+    )
+
+    with pytest.raises(ValueError, match="Invalid snapshot identifier"):
+        await documents_module.process_document_downloads(
+            harmonized_df=harmonized_df,
+            output_dir=tmp_path,
+            snapshot_id="",
         )


### PR DESCRIPTION
## Summary
- write append-only, snapshot-specific provenance manifests and reject duplicate snapshot IDs
- re-fetch documents, preserve changed versions as content-addressed raw artifacts, and isolate materialized files per snapshot
- atomically publish raw artifacts, validate reused content, and retain completed or failed run provenance

## Verification
- 83 unit tests passed; 13 integration tests deselected by default
- Ruff correctness gate passed
- package build passed

Closes #23